### PR TITLE
Add captured flag property

### DIFF
--- a/src/GlobalSnapshot.php
+++ b/src/GlobalSnapshot.php
@@ -22,6 +22,8 @@
         private array $argv;
         private ?array $__composer_autoload_files; // Native support for composer
 
+        public bool $captured = false;
+
         public function __construct() {}
 
         // Wipe all superglobals
@@ -42,6 +44,8 @@
 
 		// Store current state of superglobals
         public function capture() {
+            $this->captured = true;
+            
             foreach (array_keys($GLOBALS) as $global) {
                 $this->{$global} = $GLOBALS[$global];
             }


### PR DESCRIPTION
This PR adds a new instance flag to the `GlobalSnapshot` class that will be set `true` when a `capture()` has been run.